### PR TITLE
修复解析端口的bug

### DIFF
--- a/ServerScan Air/package/portscan/portscan.go
+++ b/ServerScan Air/package/portscan/portscan.go
@@ -3,7 +3,6 @@ package portscan
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,12 +20,14 @@ func parsePort(ports string) []int {
 			if len(ranges) < 2 {
 				continue
 			}
-			sort.Strings(ranges)
 			port = ranges[0]
 			upper = ranges[1]
 		}
 		start, _ := strconv.Atoi(port)
 		end, _ := strconv.Atoi(upper)
+		if start > end {
+			start, end = end, start
+		}
 		for i := start; i <= end; i++ {
 			scanPorts = append(scanPorts, i)
 		}
@@ -36,16 +37,16 @@ func parsePort(ports string) []int {
 
 func ProbeHosts(host string, ports <-chan int, respondingHosts chan<- string, done chan<- bool, model string) {
 	adjustedTimeout := 500 * time.Millisecond
-	for port := range ports{
+	for port := range ports {
 		start := time.Now()
-		con, err := net.DialTimeout("tcp4", fmt.Sprintf("%s:%d", host, port), 500 * time.Millisecond)
+		con, err := net.DialTimeout("tcp4", fmt.Sprintf("%s:%d", host, port), 500*time.Millisecond)
 		duration := time.Now().Sub(start)
 		if err == nil {
 			con.Close()
 			address := host + ":" + strconv.Itoa(port)
 			if model == "tcp" {
-				fmt.Printf("(TCP) Target %s is open\n",address)
-			}else {
+				fmt.Printf("(TCP) Target %s is open\n", address)
+			} else {
 				fmt.Println(address)
 			}
 			respondingHosts <- address
@@ -67,7 +68,7 @@ func ScanAllports(address string, probePorts []int, threads int, timeout time.Du
 		go ProbeHosts(address, ports, results, done, model)
 	}
 
-	for _,port := range probePorts{
+	for _, port := range probePorts {
 		ports <- port
 	}
 	close(ports)
@@ -88,34 +89,34 @@ func ScanAllports(address string, probePorts []int, threads int, timeout time.Du
 	}
 }
 
-func TCPportScan(hostslist []string,ports string,model string)  ([]string,[]string){
+func TCPportScan(hostslist []string, ports string, model string) ([]string, []string) {
 	var AliveAddress []string
 	var aliveHosts []string
 	probePorts := parsePort(ports)
 	lm := 20
-	if (len(hostslist)>5 && len(hostslist)<=50) {
+	if len(hostslist) > 5 && len(hostslist) <= 50 {
 		lm = 40
-	}else if(len(hostslist)>50 && len(hostslist)<=100){
+	} else if len(hostslist) > 50 && len(hostslist) <= 100 {
 		lm = 50
-	}else if(len(hostslist)>100 && len(hostslist)<=150){
+	} else if len(hostslist) > 100 && len(hostslist) <= 150 {
 		lm = 60
-	}else if(len(hostslist)>150 && len(hostslist)<=200){
+	} else if len(hostslist) > 150 && len(hostslist) <= 200 {
 		lm = 70
-	}else if(len(hostslist)>200){
+	} else if len(hostslist) > 200 {
 		lm = 75
 	}
 
 	thread := 5
-	if (len(probePorts)>500 && len(probePorts)<=4000) {
-		thread = len(probePorts)/100
-	}else if (len(probePorts)>4000 && len(probePorts)<=6000) {
-		thread = len(probePorts)/200
-	}else if (len(probePorts)>6000 && len(probePorts)<=10000) {
-		thread = len(probePorts)/350
-	}else if (len(probePorts)>10000 && len(probePorts)<50000){
-		thread = len(probePorts)/400
-	}else if (len(probePorts)>=50000 && len(probePorts)<=65535){
-		thread = len(probePorts)/500
+	if len(probePorts) > 500 && len(probePorts) <= 4000 {
+		thread = len(probePorts) / 100
+	} else if len(probePorts) > 4000 && len(probePorts) <= 6000 {
+		thread = len(probePorts) / 200
+	} else if len(probePorts) > 6000 && len(probePorts) <= 10000 {
+		thread = len(probePorts) / 350
+	} else if len(probePorts) > 10000 && len(probePorts) < 50000 {
+		thread = len(probePorts) / 400
+	} else if len(probePorts) >= 50000 && len(probePorts) <= 65535 {
+		thread = len(probePorts) / 500
 	}
 
 	var wg sync.WaitGroup
@@ -127,16 +128,16 @@ func TCPportScan(hostslist []string,ports string,model string)  ([]string,[]stri
 			fmt.Println(s)
 		}
 	}()
-	for _,host :=range hostslist{
+	for _, host := range hostslist {
 		wg.Add(1)
 		limiter <- struct{}{}
 		go func(host string) {
 			defer wg.Done()
-			if aliveAdd, err := ScanAllports(host, probePorts,thread, 5*time.Second,model);err == nil && len(aliveAdd)>0{
+			if aliveAdd, err := ScanAllports(host, probePorts, thread, 5*time.Second, model); err == nil && len(aliveAdd) > 0 {
 				mutex.Lock()
-				aliveHosts = append(aliveHosts,host)
-				for _,addr :=range aliveAdd{
-					AliveAddress = append(AliveAddress,addr)
+				aliveHosts = append(aliveHosts, host)
+				for _, addr := range aliveAdd {
+					AliveAddress = append(AliveAddress, addr)
 				}
 				mutex.Unlock()
 			}
@@ -145,5 +146,5 @@ func TCPportScan(hostslist []string,ports string,model string)  ([]string,[]stri
 	}
 	wg.Wait()
 	close(aliveHost)
-	return aliveHosts,AliveAddress
+	return aliveHosts, AliveAddress
 }

--- a/ServerScan Pro/package/portscan/portscan.go
+++ b/ServerScan Pro/package/portscan/portscan.go
@@ -3,7 +3,6 @@ package portscan
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,12 +20,14 @@ func parsePort(ports string) []int {
 			if len(ranges) < 2 {
 				continue
 			}
-			sort.Strings(ranges)
 			port = ranges[0]
 			upper = ranges[1]
 		}
 		start, _ := strconv.Atoi(port)
 		end, _ := strconv.Atoi(upper)
+		if start > end {
+			start, end = end, start
+		}
 		for i := start; i <= end; i++ {
 			scanPorts = append(scanPorts, i)
 		}
@@ -36,16 +37,16 @@ func parsePort(ports string) []int {
 
 func ProbeHosts(host string, ports <-chan int, respondingHosts chan<- string, done chan<- bool, model string, adjustedTimeout int) {
 	Timeout := time.Duration(adjustedTimeout) * time.Second
-	for port := range ports{
+	for port := range ports {
 		start := time.Now()
-		con, err := net.DialTimeout("tcp4", fmt.Sprintf("%s:%d", host, port), time.Duration(adjustedTimeout) * time.Second)
+		con, err := net.DialTimeout("tcp4", fmt.Sprintf("%s:%d", host, port), time.Duration(adjustedTimeout)*time.Second)
 		duration := time.Now().Sub(start)
 		if err == nil {
 			defer con.Close()
 			address := host + ":" + strconv.Itoa(port)
 			if model == "tcp" {
-				fmt.Printf("(TCP) Target %s is open\n",address)
-			}else {
+				fmt.Printf("(TCP) Target %s is open\n", address)
+			} else {
 				fmt.Println(address)
 			}
 			respondingHosts <- address
@@ -67,7 +68,7 @@ func ScanAllports(address string, probePorts []int, threads int, timeout time.Du
 		go ProbeHosts(address, ports, results, done, model, adjustedTimeout)
 	}
 
-	for _,port := range probePorts{
+	for _, port := range probePorts {
 		ports <- port
 	}
 	close(ports)
@@ -88,34 +89,34 @@ func ScanAllports(address string, probePorts []int, threads int, timeout time.Du
 	}
 }
 
-func TCPportScan(hostslist []string,ports string,model string,timeout int)  ([]string,[]string){
+func TCPportScan(hostslist []string, ports string, model string, timeout int) ([]string, []string) {
 	var AliveAddress []string
 	var aliveHosts []string
 	probePorts := parsePort(ports)
 	lm := 20
-	if (len(hostslist)>5 && len(hostslist)<=50) {
+	if len(hostslist) > 5 && len(hostslist) <= 50 {
 		lm = 40
-	}else if(len(hostslist)>50 && len(hostslist)<=100){
+	} else if len(hostslist) > 50 && len(hostslist) <= 100 {
 		lm = 50
-	}else if(len(hostslist)>100 && len(hostslist)<=150){
+	} else if len(hostslist) > 100 && len(hostslist) <= 150 {
 		lm = 60
-	}else if(len(hostslist)>150 && len(hostslist)<=200){
+	} else if len(hostslist) > 150 && len(hostslist) <= 200 {
 		lm = 70
-	}else if(len(hostslist)>200){
+	} else if len(hostslist) > 200 {
 		lm = 75
 	}
 
 	thread := 5
-	if (len(probePorts)>500 && len(probePorts)<=4000) {
-		thread = len(probePorts)/100
-	}else if (len(probePorts)>4000 && len(probePorts)<=6000) {
-		thread = len(probePorts)/200
-	}else if (len(probePorts)>6000 && len(probePorts)<=10000) {
-		thread = len(probePorts)/350
-	}else if (len(probePorts)>10000 && len(probePorts)<50000){
-		thread = len(probePorts)/400
-	}else if (len(probePorts)>=50000 && len(probePorts)<=65535){
-		thread = len(probePorts)/500
+	if len(probePorts) > 500 && len(probePorts) <= 4000 {
+		thread = len(probePorts) / 100
+	} else if len(probePorts) > 4000 && len(probePorts) <= 6000 {
+		thread = len(probePorts) / 200
+	} else if len(probePorts) > 6000 && len(probePorts) <= 10000 {
+		thread = len(probePorts) / 350
+	} else if len(probePorts) > 10000 && len(probePorts) < 50000 {
+		thread = len(probePorts) / 400
+	} else if len(probePorts) >= 50000 && len(probePorts) <= 65535 {
+		thread = len(probePorts) / 500
 	}
 
 	var wg sync.WaitGroup
@@ -127,16 +128,16 @@ func TCPportScan(hostslist []string,ports string,model string,timeout int)  ([]s
 			fmt.Println(s)
 		}
 	}()
-	for _,host :=range hostslist{
+	for _, host := range hostslist {
 		wg.Add(1)
 		limiter <- struct{}{}
 		go func(host string) {
 			defer wg.Done()
-			if aliveAdd, err := ScanAllports(host, probePorts,thread, 5*time.Second,model,timeout);err == nil && len(aliveAdd)>0{
+			if aliveAdd, err := ScanAllports(host, probePorts, thread, 5*time.Second, model, timeout); err == nil && len(aliveAdd) > 0 {
 				mutex.Lock()
-				aliveHosts = append(aliveHosts,host)
-				for _,addr :=range aliveAdd{
-					AliveAddress = append(AliveAddress,addr)
+				aliveHosts = append(aliveHosts, host)
+				for _, addr := range aliveAdd {
+					AliveAddress = append(AliveAddress, addr)
 				}
 				mutex.Unlock()
 			}
@@ -145,5 +146,5 @@ func TCPportScan(hostslist []string,ports string,model string,timeout int)  ([]s
 	}
 	wg.Wait()
 	close(aliveHost)
-	return aliveHosts,AliveAddress
+	return aliveHosts, AliveAddress
 }


### PR DESCRIPTION
1.修复输入一些端口的时候，扫描失败的情况，因为字符串比较可能不太可靠(例如：80-2222，扫描会失败)。
2.由于ide不小心修改了一下格式。
